### PR TITLE
Fix problem when recording a 2nd dance where avatar hands don't show up (fix #122)

### DIFF
--- a/src/components/states/countdown.js
+++ b/src/components/states/countdown.js
@@ -17,12 +17,6 @@ AFRAME.registerComponent('countdown', {
     }
     this.opacity = 1;
 
-    // reset avatar positions and visibility
-    leftHandEl.setAttribute('position', '0 0 0');
-    leftHandEl.setAttribute('rotation', '0 0 0');
-    rightHandEl.setAttribute('position', '0 0 0');
-    rightHandEl.setAttribute('rotation', '0 0 0');
-
     leftHandEl.setAttribute('vive-controls', {hand: 'left', model: false});
     leftHandEl.setAttribute('oculus-touch-controls', {hand: 'left', model: false});
 

--- a/src/components/states/dancing.js
+++ b/src/components/states/dancing.js
@@ -104,11 +104,23 @@ AFRAME.registerComponent('dancing', {
 
   remove: function () {
     var el = this.el;
+    var leftHandEl = el.querySelector('#leftHand');
+    var rightHandEl = el.querySelector('#rightHand');
     this.textElement.setAttribute('visible', false);
     this.counter0.setAttribute('visible', false);
     this.counter1.setAttribute('visible', false);
-    el.querySelector('#leftHand').removeAttribute('tracked-controls');
-    el.querySelector('#rightHand').removeAttribute('tracked-controls');
+    leftHandEl.removeAttribute('tracked-controls');
+    leftHandEl.removeAttribute('vive-controls');
+    leftHandEl.removeAttribute('oculus-touch-controls');
+    leftHandEl.setAttribute('position', {x: 0, y: 0, z:0});
+    leftHandEl.setAttribute('rotation', {x: 0, y: 0, z:0});
+
+    rightHandEl.removeAttribute('tracked-controls');
+    rightHandEl.removeAttribute('vive-controls');
+    rightHandEl.removeAttribute('oculus-touch-controls');
+    rightHandEl.setAttribute('position', {x: 0, y: 0, z:0});
+    rightHandEl.setAttribute('rotation', {x: 0, y: 0, z:0});
+
     document.querySelector('#room [sound]').components.sound.stopSound();
     this.avatarMimoRigEl.setAttribute('visible', false);
   }


### PR DESCRIPTION
The avatar hands were not properly reset. Two problems:

1. The `tracked-controls` component was removed and never reset because setting again `oculus-controls` and `vive-controls` with the same values as the first dance was not triggering a component init that sets the `tracked-controls` back.
2. The position and rotation of the avatar hands was not properly reset to 0 so after fixing the problem above the controllers were drifting due to the application of the delta positions coming from the controllers pose.
